### PR TITLE
Issue cache translated results

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -77,8 +77,9 @@ trait Translatable
             $this->getLocaleId($locale)
         );
 
-        if ($translation) {
-            return $translation;
+         if ($translation) { 
+            $this->translation = $translation; //Cache current translation.
+            return $translation; 
         }
 
         // Fetch fallback translation if its set in the config.


### PR DESCRIPTION
Asigned translation to Translatable field in order to reuse next time without querying again the database