### PR TITLE
Add translated attributes to arrayable attributes

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -210,8 +210,11 @@ trait Translatable
             ->where('locale_id', $localeId)
             ->where($this->getForeignKey(), $this->id)
             ->first();
-        $translation->visible = $this->translatedAttributes;
-        
+
+        if ($translation) {
+            $translation->visible = $this->translatedAttributes;
+        }
+
         return $translation;
     }
 

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -187,6 +187,16 @@ trait Translatable
 
         return parent::getAttribute($key);
     }
+    
+    /**
+    * Get an attribute array of all arrayable attributes.
+    *
+    * @return array
+    */
+    protected function getArrayableAttributes()
+    {
+        return array_merge(parent::getArrayableAttributes($this->attributes), $this->getTranslation()->getArrayableAttributes());
+    }
 
     /**
      * Fetch the translation by their locale.
@@ -196,10 +206,13 @@ trait Translatable
      */
     private function getTranslationByLocaleId($localeId)
     {
-        return $this->translatorInstance
+        $translation = $this->translatorInstance
             ->where('locale_id', $localeId)
             ->where($this->getForeignKey(), $this->id)
             ->first();
+        $translation->visible = $this->translatedAttributes;
+        
+        return $translation;
     }
 
     /**
@@ -254,6 +267,7 @@ trait Translatable
         $fillable = $this->getParentFillable($translation->getFillable());
 
         $translation->fillable($fillable);
+        $translation->visible = $this->translatedAttributes;
 
         $attributes = array_add($attributes, 'locale_id', $this->getLocaleId());
 


### PR DESCRIPTION
This includes the translated attributes in any Array or JSON representation of a translated model. This means that returning a translated model will render including the translated attribute.

Fixes https://github.com/vinkla/translator/issues/1