### PR TITLE
Cache locales

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -23,7 +23,15 @@ use Illuminate\Support\Facades\Config;
 trait Translatable
 {
     /**
-     * The current translation.
+    * The cached locales.
+    *
+    * @static
+    * @var array
+    */
+    protected static $cachedLocales = [];
+    
+    /**
+     * The cached translations.
      *
      * @var array
      */
@@ -254,11 +262,17 @@ trait Translatable
      */
     private function getLocale($locale)
     {
+        if (isset(self::$cachedLocales[$locale])) {
+            return self::$cachedLocales[$locale];
+        }
+
         $localeInstance = $this->getLocaleInstance();
 
         $column = $this->getLocaleColumn();
 
-        return $localeInstance->where($column, $locale)->first();
+        self::$cachedLocales[$locale] = $localeInstance->where($column, $locale)->first();
+
+        return self::$cachedLocales[$locale];
     }
 
     /**


### PR DESCRIPTION
Cache locales, so that only one query per locale per model is required instead of each time a translation is requested through e.g. translate.

It may be optimised further by caching these locales in the Translator class for example. That way they can be shared between models. I found that somewhat complex though (because then it should probably be using a facade).