### PR TITLE
Support eager loading translations

### DIFF
--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -77,6 +77,13 @@ trait Translatable
 
         if (!$this->translatorInstance) {
             $this->translatorInstance = new $this->translator();
+
+            // If translations have been eager loaded, copy them to the cache.
+            if (array_key_exists('translations', $this->relations)) {
+                foreach ($this->translations as $translation) {
+                    $this->cachedTranslations[$translation->locale_id] = $translation;
+                }
+            }
         }
 
         $localeId = $this->getLocaleId($locale);


### PR DESCRIPTION
This change copies over any translations loaded in the "translations" hasMany relation into the translations cache. It therefore allows eager loading of translations by using:
```
Group::with('translations')->get();
```
Or to also load translations of related objects.
```
Group::with(['translations', 'items.translations'])->get();
```
Or to load a specific translation:
```
Group::with(['translations' => function($query) {
    $query->where('locale_id' => Locale::where(Config::get('translator.column'), 'en')->id);
}])->get();
```
It's very basic and getting a specific Locale is not super nice. But it's quite versatile and most importantly I think, it allows for caching of translations. I'm interested to hear any thoughts. I feel it would also be good to add a withTranslation query scope (that optionally allows passing the locales to eager load as an argument, and maybe by default only loads the current locale), as suggested (https://github.com/vinkla/translator/issues/29#issuecomment-102022736) would be great. But that could easily be added on top of this.